### PR TITLE
[Bluetooth] Make the LE scan not block audio output

### DIFF
--- a/Source/bluetooth/HCISocket.cpp
+++ b/Source/bluetooth/HCISocket.cpp
@@ -129,9 +129,11 @@ void HCISocket::Scan(const uint16_t scanTime, const bool limited, const bool pas
     if ((_state & ACTION_MASK) == 0) {
         Command::ScanParametersLE parameters;
         parameters.Clear();
+        const uint16_t window = (limited? 0x12 : 0x10 /* 10ms */);
+        // Make sure window is smaller than interval, so the link layer has time for other Bluetooth operations during scanning.
         parameters->type = (passive? SCAN_TYPE_PASSIVE : SCAN_TYPE_ACTIVE);
-        parameters->interval = htobs((limited ? 0x12 : 0x10));
-        parameters->window = htobs((limited ? 0x12 : 0x10));
+        parameters->window = htobs(window);
+        parameters->interval = htobs(passive? (8 * window) : (4 * window));
         parameters->own_bdaddr_type = LE_PUBLIC_ADDRESS;
         parameters->filter = SCAN_FILTER_POLICY_ALL;
 
@@ -189,9 +191,11 @@ void HCISocket::Discovery(const bool enable)
         if (enable == true) {
             Command::ScanParametersLE parameters;
             parameters.Clear();
+            const uint16_t window = 0x10; // 10ms
             parameters->type = SCAN_TYPE_PASSIVE;
-            parameters->interval = htobs(0x12);
-            parameters->window = htobs(0x12);
+            // Make sure window is smaller than interval, so the link layer has time for other Bluetooth operations during scanning.
+            parameters->interval = htobs(8 * window);
+            parameters->window = htobs(window);
             parameters->own_bdaddr_type = LE_PUBLIC_ADDRESS;
             parameters->filter = SCAN_FILTER_POLICY_ALL;
 


### PR DESCRIPTION
Punch a hole in LE scanning operation and background discovery, so simultaneous high bandwidth transfer (like audio streaming) is not clogged.

Theoretically LE forward scan might need more time to locate all devices, however I have not seen any degradation myself in that regard.

Also this doesn't seem to have a negative impact on BT remote control connection or re-connection, but leaves enough link layer time for the audio stream to come through without stuttering during LE scan.
