### PR TITLE
bluetooth: fix driver selection when bcmhost is dropped.

### DIFF
--- a/Source/bluetooth/CMakeLists.txt
+++ b/Source/bluetooth/CMakeLists.txt
@@ -28,10 +28,15 @@ set(TARGET ${PROJECT_NAME})
 message("Setup ${TARGET} v${PROJECT_VERSION}")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
+option(BCM43XX "Select the serial driver for bluetooth modules found on RaspberryPi's" OFF)
 
 find_package(Bluez5UtilHeaders REQUIRED)
 find_package(BCM_HOST QUIET)
 find_package(NEXUS QUIET)
+
+if (BCM_HOST_FOUND)
+  set(BCM43XX ON) 
+endif()
 
 add_library(${TARGET} SHARED
         HCISocket.cpp
@@ -63,7 +68,7 @@ set(PUBLIC_HEADERS
         bluetooth.h
         )
 
-if (BCM_HOST_FOUND)
+if (BCM43XX)
     target_sources(${TARGET} PRIVATE drivers/BCM43XX.cpp)
 else ()
     target_sources(${TARGET} PRIVATE drivers/Basic.cpp)


### PR DESCRIPTION
If you build a full open source stack I could not find a way to figure out if I was building for a raspberry pi by analyzing the staging directory without changing buildroot. So now I just add ```-DBCM43XX=ON``` to the cmake configure options if the RPI Bluetooth firmware  package is selected. 