### PR TITLE
[Actions] Managing dependencies to make the workflows callable from different repos

### DIFF
--- a/.github/workflows/Build ThunderLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderLibraries on Linux.yml
@@ -5,7 +5,6 @@ on:
     # branches: ["main"]
   pull_request:
     branches: ["main"]
-  workflow_call:
 
 jobs:
   Thunder:

--- a/.github/workflows/Build ThunderLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderLibraries on Linux.yml
@@ -2,7 +2,7 @@ name: Build ThunderLibraries on Linux
 
 on:
   push:
-    branches: ["main"]
+    # branches: ["main"]
   pull_request:
     branches: ["main"]
   workflow_call:
@@ -13,75 +13,4 @@ jobs:
 
   ThunderLibraries:
     needs: Thunder
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        build_type: [Debug, Release, MinSizeRel]
-
-    name: Build type - ${{matrix.build_type}}
-    steps:
-    - name: Install necessary packages
-      uses: nick-fields/retry@v2
-      with:
-        timeout_minutes: 10
-        max_attempts: 10
-        command: |
-          sudo gem install apt-spy2
-          sudo apt-spy2 fix --commit --launchpad --country=US
-          sudo apt-get update
-          sudo apt install python3-pip
-          pip install jsonref
-          sudo apt install build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev libssl-dev
-
-    - name: Checkout Thunder
-      uses: actions/checkout@v3
-      with:
-        path: Thunder
-        repository: rdkcentral/Thunder
-
-    - name: Download artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: Thunder-${{matrix.build_type}}-artifact
-        path: ${{matrix.build_type}}
-
-    - name: Unpack files
-      run: |
-        tar -xvzf ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
-        rm ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
-
-    - name: Checkout ThunderLibraries
-      uses: actions/checkout@v3
-      with:
-        path: ThunderLibraries
-        repository: ${{github.repository_owner}}/ThunderLibraries
-
-    - name: Regex ThunderLibraries
-      if: contains(github.event.pull_request.body, '[Options:')
-      id: libs
-      uses: AsasInnab/regex-action@v1
-      with:
-        regex_pattern: '(?<=\[Options:).*(?=\])'
-        regex_flags: 'gim'
-        search_string: ${{github.event.pull_request.body}}
-
-    - name: Build ThunderLibraries
-      run: |
-        cmake -G Ninja -S ThunderLibraries -B ${{matrix.build_type}}/build/ThunderLibraries \
-        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
-        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
-        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
-        -DBROADCAST=ON \
-        ${{steps.libs.outputs.first_match}}
-        cmake --build ${{matrix.build_type}}/build/ThunderLibraries --target install
-
-    - name: Tar files
-      run: tar -czvf ${{matrix.build_type}}.tar.gz ${{matrix.build_type}}
-
-    - name: Upload
-      uses: actions/upload-artifact@v3
-      with:
-        name: ThunderLibraries-${{matrix.build_type}}-artifact
-        path: ${{matrix.build_type}}.tar.gz
+    uses: VeithMetro/ThunderLibraries/.github/workflows/Linux build template.yml@development/actions

--- a/.github/workflows/Build ThunderLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderLibraries on Linux.yml
@@ -2,13 +2,13 @@ name: Build ThunderLibraries on Linux
 
 on:
   push:
-    # branches: ["main"]
+    branches: ["main"]
   pull_request:
     branches: ["main"]
 
 jobs:
   Thunder:
-    uses: rdkcentral/Thunder/.github/workflows/Build Thunder on Linux.yml@master
+    uses: VeithMetro/Thunder/.github/workflows/Linux build template.yml@development/actions
 
   ThunderLibraries:
     needs: Thunder

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -48,7 +48,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: ThunderLibraries
-        repository: ${{github.repository_owner}}/ThunderLibraries
+        repository: WebPlatformForEmbedded/ThunderLibraries
 
     - name: Regex ThunderLibraries
       if: contains(github.event.pull_request.body, '[Options:')

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -1,0 +1,79 @@
+name: Build ThunderLibraries on Linux
+
+on:
+  workflow_call:
+
+jobs:
+  ThunderLibraries:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        build_type: [Debug, Release, MinSizeRel]
+
+    name: Build type - ${{matrix.build_type}}
+    steps:
+    - name: Install necessary packages
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 10
+        max_attempts: 10
+        command: |
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
+          sudo apt-get update
+          sudo apt install python3-pip
+          pip install jsonref
+          sudo apt install build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev libssl-dev
+
+    - name: Checkout Thunder
+      uses: actions/checkout@v3
+      with:
+        path: Thunder
+        repository: rdkcentral/Thunder
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: Thunder-${{matrix.build_type}}-artifact
+        path: ${{matrix.build_type}}
+
+    - name: Unpack files
+      run: |
+        tar -xvzf ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
+        rm ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
+
+    - name: Checkout ThunderLibraries
+      uses: actions/checkout@v3
+      with:
+        path: ThunderLibraries
+        repository: ${{github.repository_owner}}/ThunderLibraries
+
+    - name: Regex ThunderLibraries
+      if: contains(github.event.pull_request.body, '[Options:')
+      id: libs
+      uses: AsasInnab/regex-action@v1
+      with:
+        regex_pattern: '(?<=\[Options:).*(?=\])'
+        regex_flags: 'gim'
+        search_string: ${{github.event.pull_request.body}}
+
+    - name: Build ThunderLibraries
+      run: |
+        cmake -G Ninja -S ThunderLibraries -B ${{matrix.build_type}}/build/ThunderLibraries \
+        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
+        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
+        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
+        -DBROADCAST=ON \
+        ${{steps.libs.outputs.first_match}}
+        cmake --build ${{matrix.build_type}}/build/ThunderLibraries --target install
+
+    - name: Tar files
+      run: tar -czvf ${{matrix.build_type}}.tar.gz ${{matrix.build_type}}
+
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: ThunderLibraries-${{matrix.build_type}}-artifact
+        path: ${{matrix.build_type}}.tar.gz


### PR DESCRIPTION
Same as with the Thunder PR: https://github.com/rdkcentral/Thunder/pull/1496

This is an initial pull request - the new workflows have to be called from my branches for now (there is a dependency between the workflows), since we need to first merge new templates in each repo. Then, I'll make one more set of pull requests to redirect this new feature to master branches of our repos.

In this repo it was possible to change the required checks, and this is already done.