### PR TITLE
[Actions] Using the already merged workflows instead of my forks

### DIFF
--- a/.github/workflows/Build ThunderLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderLibraries on Linux.yml
@@ -2,14 +2,14 @@ name: Build ThunderLibraries on Linux
 
 on:
   push:
-    branches: ["main"]
+    # branches: ["main"]
   pull_request:
     branches: ["main"]
 
 jobs:
   Thunder:
-    uses: VeithMetro/Thunder/.github/workflows/Linux build template.yml@development/actions
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
 
   ThunderLibraries:
     needs: Thunder
-    uses: VeithMetro/ThunderLibraries/.github/workflows/Linux build template.yml@development/actions
+    uses: WebPlatformForEmbedded/ThunderLibraries/.github/workflows/Linux build template.yml@main

--- a/.github/workflows/Build ThunderLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderLibraries on Linux.yml
@@ -2,7 +2,7 @@ name: Build ThunderLibraries on Linux
 
 on:
   push:
-    # branches: ["main"]
+    branches: ["main"]
   pull_request:
     branches: ["main"]
 


### PR DESCRIPTION
The last set of pull requests, now the new Actions will use workflows from our repos instead of my forks, which sadly couldn't have been done in one go.