### PR TITLE
bluetooth: fix possible memset start out of bound

### DIFF
--- a/Source/bluetooth/drivers/BCM43XX.cpp
+++ b/Source/bluetooth/drivers/BCM43XX.cpp
@@ -271,12 +271,12 @@ namespace Bluetooth {
         uint32_t MACAddress(const uint8_t length, const uint8_t address[])
         {
             uint8_t data[6];
+            ::memset(data, 0, sizeof(data));
             ::memcpy(data, address, std::min(length, static_cast<uint8_t>(sizeof(data))));
-            ::memset(&(data[length]), 0, sizeof(data) - std::min(length, static_cast<uint8_t>(sizeof(data))));
             const uint16_t command = cmd_opcode_pack(OGF_VENDOR_CMD, BCM43XX_WRITE_LOCAL_ADDRESS);
 
             Exchange::Response response(Exchange::COMMAND_PKT, command);
-            uint32_t result = Exchange(Exchange::Request(Exchange::COMMAND_PKT, command, sizeof(data), address), response, 500);
+            uint32_t result = Exchange(Exchange::Request(Exchange::COMMAND_PKT, command, sizeof(data), data), response, 500);
 
             if ((result == Core::ERROR_NONE) && (response[3] != CMD_SUCCESS)) {
                 TRACE_L1("Failed to set the MAC address\n");


### PR DESCRIPTION
fixes:
```
drivers/BCM43XX.cpp: In member function ‘uint32_t WPEFramework::Bluetooth::Broadcom43XX::MACAddress(uint8_t, const uint8_t*)’:
drivers/BCM43XX.cpp:275:22: error: array subscript 7 is above array bounds of ‘uint8_t [6]’ {aka ‘unsigned char [6]’} [-Werror=array-bounds]
  275 |             ::memset(&(data[length]), 0, sizeof(data) - std::min(length, static_cast<uint8_t>(sizeof(data))));
      |                      ^~~~~~~~~~~~~~~
drivers/BCM43XX.cpp:273:21: note: while referencing ‘data’
  273 |             uint8_t data[6];
      |                     ^~~~
```