### PR TITLE
CMake: adopt CMAKE_INSTALL_<dir> for install locations

### DIFF
--- a/Source/asconnector/CMakeLists.txt
+++ b/Source/asconnector/CMakeLists.txt
@@ -84,7 +84,7 @@ target_link_libraries(
 # Installs the ASSystemService daemon
 install(
         TARGETS ASSystemService
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         )
 
 # Install the Service dependencies JSON file

--- a/Source/bluetooth/CMakeLists.txt
+++ b/Source/bluetooth/CMakeLists.txt
@@ -106,12 +106,12 @@ endif()
 
 install(
     TARGETS ${TARGET}  EXPORT ${TARGET}Targets  # for downstream dependencies
-    ARCHIVE DESTINATION lib COMPONENT libs      # static lib
-    LIBRARY DESTINATION lib COMPONENT libs      # shared lib
-    RUNTIME DESTINATION bin COMPONENT libs      # binaries
-    FRAMEWORK DESTINATION bin COMPONENT libs    # for mac
-    PUBLIC_HEADER DESTINATION include/${NAMESPACE}/bluetooth COMPONENT devel   # headers for mac (note the different component -> different package)
-    INCLUDES DESTINATION include/${NAMESPACE}   # default include path
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libs      # static lib
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libs      # shared lib
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libs      # binaries
+    FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libs    # for mac
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${NAMESPACE}/bluetooth COMPONENT devel   # headers for mac (note the different component -> different package)
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${NAMESPACE}   # default include path
 )
 
 InstallPackageConfig(

--- a/Source/bluetooth/audio/CMakeLists.txt
+++ b/Source/bluetooth/audio/CMakeLists.txt
@@ -102,17 +102,17 @@ endif()
 
 install(
     TARGETS ${TARGET}  EXPORT ${TARGET}Targets  # for downstream dependencies
-    ARCHIVE DESTINATION lib COMPONENT libs      # static lib
-    LIBRARY DESTINATION lib COMPONENT libs      # shared lib
-    RUNTIME DESTINATION bin COMPONENT libs      # binaries
-    FRAMEWORK DESTINATION bin COMPONENT libs    # for mac
-    PUBLIC_HEADER DESTINATION include/${NAMESPACE}/bluetooth/audio COMPONENT devel
-    INCLUDES DESTINATION include/${NAMESPACE}   # default include path
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libs      # static lib
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libs      # shared lib
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libs      # binaries
+    FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libs    # for mac
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${NAMESPACE}/bluetooth/audio COMPONENT devel
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${NAMESPACE}   # default include path
 )
 
 install(
     FILES ${CODEC_HEADERS}
-    DESTINATION include/${NAMESPACE}/bluetooth/audio/codecs
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${NAMESPACE}/bluetooth/audio/codecs
 )
 
 InstallPackageConfig(

--- a/Source/bluetooth/gatt/CMakeLists.txt
+++ b/Source/bluetooth/gatt/CMakeLists.txt
@@ -85,12 +85,12 @@ endif()
 
 install(
     TARGETS ${TARGET}  EXPORT ${TARGET}Targets  # for downstream dependencies
-    ARCHIVE DESTINATION lib COMPONENT libs      # static lib
-    LIBRARY DESTINATION lib COMPONENT libs      # shared lib
-    RUNTIME DESTINATION bin COMPONENT libs      # binaries
-    FRAMEWORK DESTINATION bin COMPONENT libs    # for mac
-    PUBLIC_HEADER DESTINATION include/${NAMESPACE}/bluetooth/gatt COMPONENT devel
-    INCLUDES DESTINATION include/${NAMESPACE}   # default include path
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libs      # static lib
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libs      # shared lib
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libs      # binaries
+    FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libs    # for mac
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${NAMESPACE}/bluetooth/gatt COMPONENT devel
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${NAMESPACE}   # default include path
 )
 
 InstallPackageConfig(

--- a/Source/broadcast/CMakeLists.txt
+++ b/Source/broadcast/CMakeLists.txt
@@ -111,12 +111,12 @@ target_include_directories( ${TARGET}
 # ===========================================================================================
 install(
         TARGETS ${TARGET}  EXPORT ${TARGET}Targets  # for downstream dependencies
-        ARCHIVE DESTINATION lib COMPONENT libs      # static lib
-        LIBRARY DESTINATION lib COMPONENT libs      # shared lib
-        RUNTIME DESTINATION bin COMPONENT libs      # binaries
-        FRAMEWORK DESTINATION bin COMPONENT libs    # for mac
-        PUBLIC_HEADER DESTINATION include/${NAMESPACE}/broadcast COMPONENT devel # for mac
-        INCLUDES DESTINATION include/${NAMESPACE}/broadcast # headers
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libs      # static lib
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libs      # shared lib
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libs      # binaries
+        FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libs    # for mac
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${NAMESPACE}/broadcast COMPONENT devel # for mac
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${NAMESPACE}/broadcast # headers
 )
 
 # ===========================================================================================

--- a/Source/broadcast/test/CMakeLists.txt
+++ b/Source/broadcast/test/CMakeLists.txt
@@ -26,4 +26,4 @@ target_link_libraries(BroadcastTester
         ${NAMESPACE}Core::${NAMESPACE}Core
 )   
 
-install(TARGETS BroadcastTester DESTINATION bin)
+install(TARGETS BroadcastTester DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
When playing around with a multilib environment, I noticed that if our libs are built 64bit, those libs end up in (/usr/lib) aka  /usr/lib32. This is caused because we hardcode all the install locations. Let us leverage the use of GNUInstallDirs to dynamically install binaries to the default install locations set by build systems and package generators.

This PR is part of a series of PR's
https://github.com/rdkcentral/Thunder/pull/1604
https://github.com/rdkcentral/ThunderTools/pull/93
https://github.com/rdkcentral/ThunderInterfaces/pull/347
https://github.com/rdkcentral/ThunderClientLibraries/pull/257
https://github.com/rdkcentral/ThunderNanoServices/pull/789
https://github.com/rdkcentral/ThunderUI/pull/99
https://github.com/WebPlatformForEmbedded/ThunderNanoServicesRDK/pull/301