### PR TITLE
[Actions] Removing libraries moved to the Thunder repository

### DIFF
--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -66,9 +66,8 @@ jobs:
         -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
         -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
         -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
-        -DBROADCAST=ON \
         ${{steps.libs.outputs.first_match}}
-        cmake --build ${{matrix.build_type}}/build/ThunderLibraries --target install
+#       cmake --build ${{matrix.build_type}}/build/ThunderLibraries --target install
 
     - name: Tar files
       run: tar -czvf ${{matrix.build_type}}${{matrix.architecture == '32' && '_x86' || ''}}.tar.gz ${{matrix.build_type}}


### PR DESCRIPTION
It looks like for now there is nothing to build, I tried to quickly add the libraries that are left in this repository, but neither of them builds at the moment, so it probably requires a closer look to make it work. Let's keep this workflow fairly empty for now, and maybe we can add something here in the near future.